### PR TITLE
Google Chart and Translate APIs

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -33,6 +33,11 @@
       <artifactId>appengine-api-1.0-sdk</artifactId>
       <version>1.9.59</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-translate</artifactId>
+      <version>1.70.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/portfolio/src/main/java/com/google/sps/servlets/TranslateServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/TranslateServlet.java
@@ -1,0 +1,64 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.servlets;
+
+import com.google.cloud.translate.Translate;
+import com.google.cloud.translate.TranslateOptions;
+import com.google.cloud.translate.Translation;
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/** Servelet that translates inputted text */
+@WebServlet("/translate")
+public class TranslateServlet extends HttpServlet {
+
+    private static final String REQUEST_MESSAGE_PARAM = "message";
+    private static final String REQUEST_LANGUAGE_CODE_PARAM = "languageCode";
+    private static final String REQUEST_MOCK_PARAM = "mock";
+    private static final String RESPONSE_TEXT_CONTENT = "text/html; charset=UTF-8";
+    private static final String RESPONSE_CHAR_ENCODING = "UTF-8";
+
+    /**
+     * Gets the translated message based on front end text and language code
+     * @param request The request object
+     * @param response The response object
+     */
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        // Get the request parameters
+        String originalText = request.getParameter(REQUEST_MESSAGE_PARAM);
+        String languageCode = request.getParameter(REQUEST_LANGUAGE_CODE_PARAM);
+        String mock = request.getParameter(REQUEST_MOCK_PARAM);
+
+        // Gives option to mock the Translation API for testing
+        String translatedText;
+        if (mock != null) {
+            translatedText = originalText + languageCode;
+        } else {
+            Translate translate = TranslateOptions.getDefaultInstance().getService();
+            Translation translation = 
+                translate.translate(originalText, Translate.TranslateOption.targetLanguage(languageCode));
+            translatedText = translation.getTranslatedText();
+        }
+
+        // Output the translation
+        response.setContentType(RESPONSE_TEXT_CONTENT);
+        response.setCharacterEncoding(RESPONSE_CHAR_ENCODING);
+        response.getWriter().println(translatedText);
+    }
+}

--- a/portfolio/src/main/java/com/google/sps/servlets/TranslateServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/TranslateServlet.java
@@ -22,6 +22,7 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.Arrays;
 
 /** Servelet that translates inputted text */
 @WebServlet("/translate")
@@ -32,6 +33,10 @@ public class TranslateServlet extends HttpServlet {
     private static final String REQUEST_MOCK_PARAM = "mock";
     private static final String RESPONSE_TEXT_CONTENT = "text/html; charset=UTF-8";
     private static final String RESPONSE_CHAR_ENCODING = "UTF-8";
+    private static final String EMPTY_RESPONSE = "";
+    private static final String INVALID_LANGUAGE_CODE_EXCEPTION = "Exception: Invalid language code used";
+    private static final String NULL_REQUEST_PARAMETERS_EXCEPTION = "Exception: Null text or language code parameters";
+    private static String LANGUAGE_CODES_ARRAY[] = {"en", "zh", "es", "hi", "ar"};
 
     /**
      * Gets the translated message based on front end text and language code
@@ -45,6 +50,23 @@ public class TranslateServlet extends HttpServlet {
         String languageCode = request.getParameter(REQUEST_LANGUAGE_CODE_PARAM);
         String mock = request.getParameter(REQUEST_MOCK_PARAM);
 
+        // Set the response type
+        response.setContentType(RESPONSE_TEXT_CONTENT);
+        response.setCharacterEncoding(RESPONSE_CHAR_ENCODING);
+
+        if (originalText == null || languageCode == null) {
+            System.out.println(NULL_REQUEST_PARAMETERS_EXCEPTION);
+            response.getWriter().print(EMPTY_RESPONSE);
+            return;
+        }
+
+        // Checks for validity of request parameters
+        if (Arrays.asList(LANGUAGE_CODES_ARRAY).indexOf(languageCode) < 0) {
+            System.out.println(INVALID_LANGUAGE_CODE_EXCEPTION);
+            response.getWriter().print(EMPTY_RESPONSE);
+            return;
+        }
+
         // Gives option to mock the Translation API for testing
         String translatedText;
         if (mock != null) {
@@ -57,8 +79,6 @@ public class TranslateServlet extends HttpServlet {
         }
 
         // Output the translation
-        response.setContentType(RESPONSE_TEXT_CONTENT);
-        response.setCharacterEncoding(RESPONSE_CHAR_ENCODING);
-        response.getWriter().println(translatedText);
+        response.getWriter().print(translatedText);
     }
 }

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -327,9 +327,15 @@
                 </div>
             </div>
 
+            <br>
+            <br>
             <div id="chart-container">
-                <div id="pokemon-chart" class="chart-div"></div>
-                <div id="moves-chart" class="chart-div"></div>
+                <p>
+                    And here's some fun data about the distribution of different Pokemon species and Pokemon moves in terms Pokemon types! The
+                    data is fetched from PokeAPI, a RESTful Pokemon API, through front-end fetches. PokeAPI currently has data through Generation 7. 
+                </p>
+                <div id="pokemon-chart" class="chart-div" align="center"></div>
+                <div id="moves-chart" class="chart-div" align="center"></div>
             </div>
             <hr>
 

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -71,9 +71,9 @@
                     </div>
                     <div class="about-item">
                         <div id="slideshow">
-                            <div><img src="/images/slideshow_1.png"></div>
-                            <div><img src="/images/slideshow_2.png"></div>
-                            <div><img src="/images/slideshow_3.png"></div> 
+                            <div><img class="slideshow-img" src="/images/slideshow_1.png"></div>
+                            <div><img class="slideshow-img" src="/images/slideshow_2.png"></div>
+                            <div><img class="slideshow-img" src="/images/slideshow_3.png"></div> 
                         </div>
                     </div>
                 </div>
@@ -327,7 +327,11 @@
                 </div>
             </div>
 
-            <div id="chart-container"></div>
+            <div id="chart-container">
+                <div id="pokemon-chart" class="chart-div"></div>
+                <div id="moves-chart" class="chart-div"></div>
+            </div>
+            <hr>
 
             <div id="comments">
                 <h2>Comments</h2>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -363,6 +363,15 @@
                         <br class="hideable-br">
                         <br class="hideable-br">
                         <br class="hideable-br">
+                        <label for="language">Select a language:</label>
+                        <select name="language" id="language-select">
+                            <option value="en" select="selected">English</option>
+                            <option value="zh">Chinese</option>
+                            <option value="es">Spanish</option>
+                            <option value="hi">Hindi</option>
+                            <option value="ar">Arabic</option>
+                        </select>
+                        <br>
                         <label for="limit">Filter most recent:</label>
                         <input type="number" id="comment-limit-input" name="limit" min="1" oninput="validity.valid||(value='');">
                         <button type="button" id="comment-limit-button">Filter</button>
@@ -375,7 +384,6 @@
             </div>
             <br>
             <br>
-
             <div id="contact">
                 <h2>Contact</h2>
                 <div id="icons-div">

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -178,11 +178,17 @@ function loadComments(query) {
         for (var i = 0; i < json.length; i++) {
             display += '<tr><td>';
             display += '<b>' + json[i].username + ': </b>';
-            display += json[i].message;
+            display += '<span class="message-text">' + json[i].message + '</span>';
             display += '</tr></td>';
         }
         display += '</table>';
         $('#comments-scroll').html(display);
+        
+        // Continues to use current language code selection
+        var currentLanguageCode = $('#language-select').val();
+        if (currentLanguageCode != 'en') {
+            translateComments(currentLanguageCode);
+        }
     });
 }
 
@@ -353,6 +359,28 @@ function drawPokemonDataCharts() {
 }
 
 /**
+ * Translates the comments backend fetches
+ * @param {String} languageCode The language code to translate to
+ */
+function translateComments(languageCode) {
+    // Gets all message texts and performs a fetch for each message
+    $('.message-text').each((index, value) => {
+        var message = value.innerText;
+        value.innerText = 'Loading...';
+        const params = new URLSearchParams();
+        params.append('message', message);
+        params.append('languageCode', languageCode);
+
+        fetch('/translate', {
+            method: 'POST',
+            body: params,
+        }).then((response) => response.text()).then((translatedMessage) => {
+            value.innerText = translatedMessage;
+        }); 
+    });
+}
+
+/**
  * Executes when document is loaded
  */
  $(document).ready(function() {
@@ -436,9 +464,16 @@ function drawPokemonDataCharts() {
         });
     });
 
+    // Google Authentication API 
     manageLogin();
 
+    // Google Chart API
     google.charts.load('current', {'packages':['corechart']});
     google.charts.setOnLoadCallback(drawPokemonDataCharts);
+
+    // Google Translation API
+    $('#language-select').change(function() {
+        translateComments($(this).val());
+    });
     
  });

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -33,7 +33,7 @@ const POKEMON_TYPES = [
 ];
 const POKEMON_TYPE_COLORS = [
     '#999999', '#ff3300', '#990000', '#3385ff',
-    '#ccccff', '#33cc33', '#9900cc', '#ffff66',
+    '#ccccff', '#33cc33', '#9900cc', '#ffd11a',
     '#e6ac00', '#cc66ff', '#cc8800', '#b3ecff',
     '#99cc00', '#6666ff', '#666699', '#595959',
     '#d0d0e1', '#ffccff'
@@ -316,29 +316,33 @@ function drawPokemonDataCharts() {
             return response.json();
         }));
     }).then((data) => {
+        // Sets up tables to insert data to graph
         const pokemonTable = new google.visualization.DataTable();
         const movesTable = new google.visualization.DataTable();
-
         pokemonTable.addColumn('string', 'Type');
         pokemonTable.addColumn('number', 'Count');
         movesTable.addColumn('string', 'Type');
         movesTable.addColumn('number', 'Count');
 
+        // Data insertion into the two tables
         data.forEach((typeData) => {
             pokemonTable.addRow([typeData.name, typeData.pokemon.length]);
             movesTable.addRow([typeData.name, typeData.moves.length]);
         });
 
+        // Specifies the options of each graph and plots it in the given div
         var pokemonOptions = {
             title: 'Pokemon Species of Each Type',
             colors: POKEMON_TYPE_COLORS,
+            chartArea: {'width': '80%', 'height': '80%'},
+            legend: {'position':'right','alignment':'center'},
         }
-
         var movesOptions = {
             title: 'Pokemon Moves of Each Type',
             colors: POKEMON_TYPE_COLORS,
+            chartArea: {'width': '80%', 'height': '80%'},
+            legend: {'position':'right','alignment':'center'},
         }
-
         var pokemonChartDiv = document.getElementById('pokemon-chart');
         const pokemonChart = new google.visualization.PieChart(pokemonChartDiv);
         pokemonChart.draw(pokemonTable, pokemonOptions);

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -31,6 +31,13 @@ const POKEMON_TYPES = [
     'bug', 'dragon', 'ghost', 'dark', 
     'steel', 'fairy'
 ];
+const POKEMON_TYPE_COLORS = [
+    '#999999', '#ff3300', '#990000', '#3385ff',
+    '#ccccff', '#33cc33', '#9900cc', '#ffff66',
+    '#e6ac00', '#cc66ff', '#cc8800', '#b3ecff',
+    '#99cc00', '#6666ff', '#666699', '#595959',
+    '#d0d0e1', '#ffccff'
+];
 
 
 /**
@@ -324,10 +331,12 @@ function drawPokemonDataCharts() {
 
         var pokemonOptions = {
             title: 'Pokemon Species of Each Type',
+            colors: POKEMON_TYPE_COLORS,
         }
 
         var movesOptions = {
             title: 'Pokemon Moves of Each Type',
+            colors: POKEMON_TYPE_COLORS,
         }
 
         var pokemonChartDiv = document.getElementById('pokemon-chart');

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -353,10 +353,16 @@ tr:nth-child(even) {background-color: #f2f2f2;}
     clear: both;
 }
 
+#chart-container > p {
+    padding-left: 5%;
+    padding-right: 5%;
+}
+
 .chart-div {
     float: left;
     width: 50%;
     padding: 15px;
+    padding-top: 0px;
     height: 700px;
 }
 

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -357,6 +357,12 @@ tr:nth-child(even) {background-color: #f2f2f2;}
     float: left;
     width: 50%;
     padding: 15px;
-    height: 450px;
+    height: 700px;
+}
+
+@media screen and (max-width: 1200px) {
+  .chart-div {
+    width: 100%;
+  }
 }
 /* End styles for pie charts */

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -65,6 +65,10 @@ img.modal-btn {
     position: absolute; 
 }
 
+.slideshow-img {
+    bottom: 0px;
+}
+
 #greeting-container {
     margin-top: 20px;
 }
@@ -287,7 +291,6 @@ div#nav-content {
 /* Begin styles for comments section */
 #comments-section {
     box-sizing: border-box;
-
 }
 
 #comments-section:after {
@@ -338,3 +341,22 @@ table {
 
 tr:nth-child(even) {background-color: #f2f2f2;}
 /* End styles for comments section */
+
+/* Begin styles for pie charts */
+#chart-container {
+    box-sizing: border-box;
+}
+
+#chart-container:after {
+    content: "";
+    display: table;
+    clear: both;
+}
+
+.chart-div {
+    float: left;
+    width: 50%;
+    padding: 15px;
+    height: 450px;
+}
+/* End styles for pie charts */


### PR DESCRIPTION
Integrated portfolio with the Google Chart and Google Translate APIs. 

For Google Chart:
- Fetched data from online API of Pokemon types
- Displayed two pie charts, one with the number of Pokemon species of each type, and one with the number of Pokemon moves with each type
- Accommodated for screen sizes by changing positions of pie charts before the charts overlap

For Google Translate: 
- Add select dropdown, and changes language of comments when dropdown selection changes 

However, for Google Translate, the language selection does not persist through refreshes (e.g. when a user submits a comment or changes their display name). I believe that could be fixed by adding a url query parameter though. 

The current state of the portfolio, including this pull request, is located at [https://yimingnzhao-step-2020.appspot.com/](https://yimingnzhao-step-2020.appspot.com/)