### PR TITLE
Comment Language Persistence and Page Scrolling Adjustments

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -41,15 +41,20 @@ public class DataServlet extends HttpServlet {
     private static final String DEFAULT_DISPLAY_NAME = "Anon. User";
     private static final String RESPONSE_JSON_CONTENT = "application/json;";
     private static final String REQUEST_COMMENT_LIMIT_PARAM = "limit";
+    private static final String REQUEST_MESSAGE_PARAM = "message";
+    private static final String REQUEST_LANGUAGE_CODE_PARAM = "language-code";
     private static final String DATASTORE_COMMENT_KIND = "Comment";
+    private static final String DATASTORE_COMMENT_MESSAGE_PARAM = "message";
     private static final String DATASTORE_COMMENT_TIMESTAMP_PARAM = "timestamp";
     private static final String DATASTORE_COMMENT_USER_ID_PARAM = "userId";
-    private static final String DATASTORE_COMMENT_MESSAGE_PARAM = "message";
     private static final String DATASTORE_USER_DATA_KIND = "UserData";
     private static final String DATASTORE_USER_DATA_ID_PARAM = "id";
     private static final String DATASTORE_USER_DATA_NAME_PARAM = "displayName";
-    private static final String REDIRECT_URL = "/#comments";
-
+    private static final String REDIRECT_URL_PATH = "/";
+    private static final String REDIRECT_URL_QUERY = "?";
+    private static final String REDIRECT_URL_QUERY_LANGUAGE_PARAM = "hl=";
+    private static final String REDIRECT_URL_FRAGMENT = "#comments";
+    private static String LANGUAGE_CODES_ARRAY[] = {"en", "zh", "es", "hi", "ar"};
 
 
 
@@ -117,14 +122,23 @@ public class DataServlet extends HttpServlet {
         // Breaks from method if the user is not logged in
         UserService userService = UserServiceFactory.getUserService();
         if (!userService.isUserLoggedIn()) {
-            response.sendRedirect(REDIRECT_URL);
+            response.sendRedirect(REDIRECT_URL_PATH);
             return;
         }
 
+        // Gets necessary data from system and request
         String userId = userService.getCurrentUser().getUserId();
         String userEmail = userService.getCurrentUser().getEmail();
-        String message = request.getParameter(DATASTORE_COMMENT_MESSAGE_PARAM);
+        String message = request.getParameter(REQUEST_MESSAGE_PARAM);
+        String languageCode = request.getParameter(REQUEST_LANGUAGE_CODE_PARAM);
         long timestamp = System.currentTimeMillis();
+
+        // Builds redirect URL based on whether the request language code is valid
+        String redirectURL = REDIRECT_URL_PATH;
+        if (languageCode != null && Arrays.asList(LANGUAGE_CODES_ARRAY).indexOf(languageCode) >= 0) {
+            redirectURL += REDIRECT_URL_QUERY + REDIRECT_URL_QUERY_LANGUAGE_PARAM + languageCode;
+        }
+        redirectURL += REDIRECT_URL_FRAGMENT;
 
         // Creates database entry Entity and populates its parameters
         Entity commentEntity = new Entity(DATASTORE_COMMENT_KIND);
@@ -134,7 +148,7 @@ public class DataServlet extends HttpServlet {
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
         datastore.put(commentEntity);
 
-        response.sendRedirect(REDIRECT_URL);
+        response.sendRedirect(redirectURL);
     }
 
     /**

--- a/portfolio/src/main/java/com/google/sps/servlets/UserDataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/UserDataServlet.java
@@ -45,7 +45,12 @@ public class UserDataServlet extends HttpServlet {
     private static final String DATASTORE_USER_DATA_NAME_PARAM = "displayName";
     private static final String DATASTORE_USER_DATA_EMAIL_PARAM = "email"; 
     private static final String REQUEST_NAME_PARAM = "name";
-    private static final String REDIRECT_URL = "/#comments";
+    private static final String REQUEST_LANGUAGE_CODE_PARAM = "language-code";
+    private static final String REDIRECT_URL_PATH = "/";
+    private static final String REDIRECT_URL_QUERY = "?";
+    private static final String REDIRECT_URL_QUERY_LANGUAGE_PARAM = "hl=";
+    private static final String REDIRECT_URL_FRAGMENT = "#comments";
+    private static String LANGUAGE_CODES_ARRAY[] = {"en", "zh", "es", "hi", "ar"};
 
     /**
      * Gets the potential display name of the current user
@@ -91,13 +96,22 @@ public class UserDataServlet extends HttpServlet {
         // Breaks from method if the user is not logged in
         UserService userService = UserServiceFactory.getUserService();
         if (!userService.isUserLoggedIn()) {
-            response.sendRedirect(REDIRECT_URL);
+            response.sendRedirect(REDIRECT_URL_PATH);
             return;
         }
 
+        // Gets necessary data from request and UserService
         String id = userService.getCurrentUser().getUserId();
         String email = userService.getCurrentUser().getEmail();
         String displayName = request.getParameter(REQUEST_NAME_PARAM);
+        String languageCode = request.getParameter(REQUEST_LANGUAGE_CODE_PARAM);
+
+        // Builds redirect URL based on whether the request langauge code is valid
+        String redirectURL = REDIRECT_URL_PATH;
+        if (languageCode != null && Arrays.asList(LANGUAGE_CODES_ARRAY).indexOf(languageCode) >= 0) {
+            redirectURL += REDIRECT_URL_QUERY + REDIRECT_URL_QUERY_LANGUAGE_PARAM + languageCode;
+        }
+        redirectURL += REDIRECT_URL_FRAGMENT;
 
         // Sets the display name of the current user and stores it in the database
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
@@ -107,6 +121,6 @@ public class UserDataServlet extends HttpServlet {
         entity.setProperty(DATASTORE_USER_DATA_EMAIL_PARAM, email);
         datastore.put(entity);
 
-        response.sendRedirect(REDIRECT_URL);
+        response.sendRedirect(redirectURL);
     }
 }

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -13,12 +13,12 @@
 
     <body>
         <div class="sidebar">
-            <a class="active" href="#">Home</a>
-            <a href="#about">About Me</a>
-            <a href="#work">Work </a>        
-            <a href="#projects">Projects</a>
-            <a href="#comments">Comments</a>
-            <a href="#contact">Contact</a>
+            <a class="active scroll" href="#">Home</a>
+            <a class="scroll" href="#about">About Me</a>
+            <a class="scroll" href="#work">Work </a>        
+            <a class="scroll" href="#projects">Projects</a>
+            <a class="scroll" href="#comments">Comments</a>
+            <a class="scroll" href="#contact">Contact</a>
         </div>
 
         <div id="nav-content">

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -347,12 +347,14 @@
                         <form action="/user-data" name="display-form" onsubmit="return validateNameForm()" method="post">
                             <label for="name">New Display Name: </label>
                             <input type="text" name="name"></input>
+                            <input type="hidden" name="language-code" value="">
                             <input type="submit">
                         </form>
                         <br class="hideable-br">
                         <form action="/data" name="comment-form" onsubmit="return validateCommentForm()" method="post">
                             <label for="message">Please leave a comment:</label><br>
                             <textarea name="message" rows="15"></textarea>
+                            <input type="hidden" name="language-code" value="">
                             <br>
                             <br>
                             <input type="submit">

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -166,8 +166,9 @@ function startTypewriterAnimation() {
 /**
  * Loads comments from database, with option to specify the maximum loaded comments
  * @param {string} query The number of comments that should be fetched
+ * @param {string} currentLanguage The language code to use
  */
-function loadComments(query) {
+function loadComments(query, currentLanguage) {
     // Creates the fetch URL with specified maximum limit of comments
     var fetchURL = '/data';
     fetchURL = (hasOnlyDigits(query)) ? fetchURL + '?limit=' + query : fetchURL;
@@ -184,10 +185,20 @@ function loadComments(query) {
         display += '</table>';
         $('#comments-scroll').html(display);
         
+        const urlParams = new URLSearchParams(window.location.search);
+        var languageCode = urlParams.get('hl');
+        if ($('#language-select option[value="' + currentLanguage + '"]').index() >= 0) {
+            languageCode = currentLanguage;
+        } 
+
+        var languageCodeIndex = $('#language-select option[value="' + languageCode + '"]').index();
+        if (languageCodeIndex >= 0) {
+            $('#language-select')[0].selectedIndex = languageCodeIndex;
+        }
+        
         // Continues to use current language code selection
-        var currentLanguageCode = $('#language-select').val();
-        if (currentLanguageCode != 'en') {
-            translateComments(currentLanguageCode);
+        if ($('#language-select').val() != 'en') {
+            translateComments($('#language-select').val());
         }
     });
 }
@@ -202,9 +213,10 @@ function validateCommentForm() {
         alert("Message field must be filled out");
         return false;
     }
+    document.forms['comment-form']['language-code'].value = $('#language-select').val();
 
     // Escapes HTML characters before submitting
-    //document.forms['comment-form']['message'].value = escapeHtml(message);
+    document.forms['comment-form']['message'].value = escapeHtml(message);
     return true;
 }
 
@@ -227,6 +239,7 @@ function validateNameForm() {
         return false;
     } 
     document.forms['display-form']['name'].value = $.trim(name);
+    document.forms['display-form']['language-code'].value = $('#language-select').val();
     return true;
 }
 
@@ -370,6 +383,7 @@ function translateComments(languageCode) {
         const params = new URLSearchParams();
         params.append('message', message);
         params.append('languageCode', languageCode);
+        params.append('mock', 'mock');
 
         fetch('/translate', {
             method: 'POST',
@@ -404,7 +418,7 @@ function translateComments(languageCode) {
     // Animates the typing animation
     window.onload = function() {
         startTypewriterAnimation();
-        loadComments('');
+        loadComments('', '');
     };
 
     // Opens modal for extra descriptions for of work and projects
@@ -442,7 +456,7 @@ function translateComments(languageCode) {
 
     // Loads comments based on the limit passed
     $('#comment-limit-button').click(function() {
-        loadComments($('#comment-limit-input').val());
+        loadComments($('#comment-limit-input').val(), $('#language-select').val());
     });
 
     // Deletes all comments from database

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -185,12 +185,17 @@ function loadComments(query, currentLanguage) {
         display += '</table>';
         $('#comments-scroll').html(display);
         
+        // Grabs the host language from the URL query
         const urlParams = new URLSearchParams(window.location.search);
         var languageCode = urlParams.get('hl');
+
+        // The priority of language use is:
+        //   1. Front end change via GET request, which uses the currentLanguage param
+        //   2. Back end change via POST request, which uses the URL query
+        //   3. Default language (English) if language codes are invalid
         if ($('#language-select option[value="' + currentLanguage + '"]').index() >= 0) {
             languageCode = currentLanguage;
         } 
-
         var languageCodeIndex = $('#language-select option[value="' + languageCode + '"]').index();
         if (languageCodeIndex >= 0) {
             $('#language-select')[0].selectedIndex = languageCodeIndex;

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -385,6 +385,11 @@ function translateComments(languageCode) {
  */
  $(document).ready(function() {
 
+     // Animates scroll behavior only when navigating within page
+     $('.scroll').click(function() {
+         $('html').css('scroll-behavior', 'smooth');
+     });
+
      // Animates the picture slideshow
      $('#slideshow > div:gt(0)').hide();
      setInterval(function() {

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -383,7 +383,6 @@ function translateComments(languageCode) {
         const params = new URLSearchParams();
         params.append('message', message);
         params.append('languageCode', languageCode);
-        params.append('mock', 'mock');
 
         fetch('/translate', {
             method: 'POST',

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -1,5 +1,5 @@
 html {
-    scroll-behavior: smooth;
+    scroll-behavior: auto;
 }
 
 body {


### PR DESCRIPTION
For page scrolling:
- The scrolling animation will only occur if a selection from the navigation bar is clicked
- A back-end redirect to a URL fragment, (e.g. redirects to [url]#comments) will not have the animation that starts on the top of the page and scrolls down

For comment language persistence:
- Added query to url to ensure language persists throughout POST requests
- Modified loadComments JS method to ensure language persists through front end changes via GET requests

The current state of my portfolio is deployed at [https://yimingnzhao-step-2020.appspot.com/](https://yimingnzhao-step-2020.appspot.com/)

A next step might be to centralize language persistence. I was thinking of using cookies instead of url queries and storing front end JS variables. Would that be advisable, or is there a better way?